### PR TITLE
Potential solution to issue #8

### DIFF
--- a/src/AspNetCoreCsvImportExport/Formatters/CsvFormatterOptions.cs
+++ b/src/AspNetCoreCsvImportExport/Formatters/CsvFormatterOptions.cs
@@ -7,5 +7,7 @@
         public string CsvDelimiter { get; set; } = ";";
 
         public string Encoding { get; set; } = "ISO-8859-1";
+        
+        public bool UseNewtonsoftJsonDataAnnotations { get; set; } = false;
     }
 }

--- a/src/AspNetCoreCsvImportExport/Formatters/CsvInputFormatter.cs
+++ b/src/AspNetCoreCsvImportExport/Formatters/CsvInputFormatter.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Net.Http.Headers;
 using System.Text;
+using Newtonsoft.Json;
 
 namespace AspNetCoreCsvImportExport.Formatters
 {
@@ -99,8 +100,11 @@ namespace AspNetCoreCsvImportExport.Formatters
                 {
                     var itemTypeInGeneric = list.GetType().GetTypeInfo().GenericTypeArguments[0];
                     var item = Activator.CreateInstance(itemTypeInGeneric);
-                    var properties = item.GetType().GetProperties();
-                    for (int i = 0;i<values.Length; i++)
+                    var properties = _options.UseNewtonsoftJsonDataAnnotations
+                        ? item.GetType().GetProperties().Where(pi => !pi.GetCustomAttributes<JsonIgnoreAttribute>().Any()).ToArray()
+                        : item.GetType().GetProperties();
+                    // TODO: Maybe refactor to not use positional mapping?, mapping by index could generate errors pretty easily :)
+                    for (int i = 0; i < values.Length; i++)
                     {
                         properties[i].SetValue(item, Convert.ChangeType(values[i], properties[i].PropertyType), null);
                     }

--- a/src/AspNetCoreCsvImportExport/Formatters/CsvOutputFormatter.cs
+++ b/src/AspNetCoreCsvImportExport/Formatters/CsvOutputFormatter.cs
@@ -75,7 +75,7 @@ namespace AspNetCoreCsvImportExport.Formatters
             {
                 var values = _options.UseNewtonsoftJsonDataAnnotations
                     ? itemType.GetProperties().Where(pi => !pi.GetCustomAttributes<JsonIgnoreAttribute>(false).Any())    // Only get the properties that do not define JsonIgnore
-                        .Select(GetDisplayNameFromNewtonsoftJsonAnnotations)  // Transformed to method group as shown left. Was => .Select(pi => GetDisplayName(pi));
+                        .Select(GetDisplayNameFromNewtonsoftJsonAnnotations)
                     : itemType.GetProperties().Select(pi => pi.GetCustomAttribute<DisplayAttribute>(false)?.Name ?? pi.Name);
 
                 await streamWriter.WriteLineAsync(string.Join(_options.CsvDelimiter, values));

--- a/src/AspNetCoreCsvImportExport/Formatters/CsvOutputFormatter.cs
+++ b/src/AspNetCoreCsvImportExport/Formatters/CsvOutputFormatter.cs
@@ -51,6 +51,21 @@ namespace AspNetCoreCsvImportExport.Formatters
 
             return false;
         }
+        
+        /// <summary>
+        /// Returns the JsonProperty data annotation name
+        /// </summary>
+        /// <param name="pi">Property Info</param>
+        /// <returns></returns>
+        private string GetDisplayNameFromNewtonsoftJsonAnnotations(PropertyInfo pi)
+        {
+            if (pi.GetCustomAttribute<JsonPropertyAttribute>(false)?.PropertyName is string value)
+            {
+                return value;
+            }
+
+            return pi.GetCustomAttribute<DisplayAttribute>(false)?.Name ?? pi.Name;
+        }
 
         public async override Task WriteResponseBodyAsync(OutputFormatterWriteContext context)
         {

--- a/src/AspNetCoreCsvImportExport/Model/LocalizationRecord.cs
+++ b/src/AspNetCoreCsvImportExport/Model/LocalizationRecord.cs
@@ -1,16 +1,20 @@
-﻿using System;
+using System;
+using Newtonsoft.Json;
 
 namespace AspNetCoreCsvImportExport.Model
 {
     public class LocalizationRecord
     {
-        public long Id { get; set; }
+        [JsonIgnore]
+        public long? Id { get; set; }
 
+        [JsonProperty(PropertyName = "CustomKeyName")]
         public string Key { get; set; }
 
         public string Text { get; set; }
 
         public string LocalizationCulture { get; set; }
+        
         public string ResourceKey { get; set; }
     }
 }


### PR DESCRIPTION
Adding support for Newtonsoft Json data annotations to specify which properties to export and edit the property names in the same way as is done with Newtonsoft Json serializer.

This adds a dependency on Newtonsoft.Json so if has to be evaluated if it is required or not and if it's a good fit for the majority (considering it is already included in Asp.Net Core default templates)

It could be good to add support for DataContract and DataMemberAttribute and its opposite, IgnoreDataMemberAttribute eventually. These are supported by default by Newtonsoft.Json, so it could remove the need to use a custom attribute from this dependency. 